### PR TITLE
Add cache & metadata injection to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,15 +9,30 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            # Setup and installl Node and JS dependencies
+            # Setup Node v20
             - uses: actions/setup-node@v3
               with:
                   node-version: 20
-            - run: npm ci
+            - name: Setup Pages
+              uses: actions/configure-pages@v3
+              with:
+                  # Automatically inject basePath in your Next.js configuration file and disable
+                  # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
+                  static_site_generator: next
+            - name: Restore cache
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      .next/cache
+                  # Generate a new cache whenever packages or source files change.
+                  key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+                  # If source files changed but packages didn't, rebuild from a prior cache.
+                  restore-keys: |
+                      ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
             # Build the project
             - name: Build the app
               run: npm run build
-            # Upload artifacts
+            # Upload artifacts to Github Pages
             - name: Upload GitHub Pages artifacts
               uses: actions/upload-pages-artifact@v1.0.8
               with:
@@ -30,6 +45,12 @@ jobs:
         permissions:
             pages: write # to deploy to Pages
             id-token: write # to verify the deployment originates from an appropriate source
+
+        # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+        # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+        concurrency:
+            group: "pages"
+            cancel-in-progress: false
 
         environment:
             name: github-pages

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,7 @@ export const metadata: Metadata = {
         "checklist, lean, agile, web development, python, django, javascript, react, python development, django development, javascript development, react development, development, software development, ux design, product discovery, code review, test coverage, mvp, api, api experts, django rest framework, SPA, single page application",
     themeColor: "#52D171",
     colorScheme: "dark",
+    metadataBase: new URL("https://devchecklists.com"),
     twitter: {
         card: "summary_large_image",
         site: "@vintasoftware",


### PR DESCRIPTION
Add the following to CI:
- Restore Github Action cache to speed up builds
- Add basePath and disable server side image optimization (Incompatible with static site export)
- Only run one deploy job at a time

Also:
- Adds metadataBase URL to correctly setup metadata links