### PR TITLE
Fix checklist padding

### DIFF
--- a/src/app/checklist/[checklist_slug]/[locale]/page.css
+++ b/src/app/checklist/[checklist_slug]/[locale]/page.css
@@ -1,0 +1,8 @@
+/* Remove the top margin from the first h2 element if it's not following a h1 element */
+article h2:first-of-type {
+    margin-top: 0;
+}
+
+article h1 ~ h2:first-of-type {
+    margin-top: 2em;
+}

--- a/src/app/checklist/[checklist_slug]/[locale]/page.tsx
+++ b/src/app/checklist/[checklist_slug]/[locale]/page.tsx
@@ -1,4 +1,3 @@
-import { Avatar } from "@/components/avatar";
 import {
     Checklist as IChecklist,
     ChecklistService,
@@ -7,10 +6,11 @@ import { Tags } from "@/components/tag";
 import { CircleStackIcon } from "@heroicons/react/24/solid";
 import { Checklist } from "@/components/checklist";
 import { LocalesDropdown } from "@/components/localeDropdown";
-import Link from "next/link";
 import { Metadata } from "next";
 import Script from "next/script";
 import { Author } from "@/components/author";
+
+import "./page.css";
 
 interface ChecklistParam {
     checklist_slug: string;
@@ -115,7 +115,7 @@ const ChecklistPage = ({
                     </div>
                 </div>
 
-                <article className="prose prose-invert max-w-3xl rounded-md bg-dark-gray px-10 py-4 prose-ul:list-none">
+                <article className="prose prose-invert max-w-3xl rounded-md bg-dark-gray px-10 py-8 prose-ul:list-none">
                     <Checklist checklistHTML={checklist.contentHtml} />
                 </article>
             </div>


### PR DESCRIPTION
Better paddings for checklist
Tested with checklist beginning with `# Header` and `## Header`

![Screenshot_20230614_162617](https://github.com/vintasoftware/devchecklists.com-content/assets/8880488/16cb7f35-7e55-4f97-bd60-813a6f856222)
![Screenshot_20230614_162622](https://github.com/vintasoftware/devchecklists.com-content/assets/8880488/9cb0e56b-2abc-4111-b6d5-d9ad010ac696)
